### PR TITLE
theme button fixed position 

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -7,8 +7,9 @@
 /* header elements */
 .header{
   display: flex;
-  align-items: center;
-  justify-content: right;
+  position: fixed;
+  right: 0;
+  z-index: 1;
 }
 
 .theme-button {


### PR DESCRIPTION
This is minor patch for issue below:
Switch button for Night mode #76

Makes theme button to float over the elements and scroll down with a screen. That way user have access to the button any time and can switch to the dark or light mode whatever he wants

https://github.com/michaella23/bootcamp-collab/assets/97144951/97549102-168b-4c83-a383-7cb06af585c6
