### PR TITLE
#102 Issue check load count

### DIFF
--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -172,8 +172,11 @@ const createScrimbaContributorsElements = function (index) {
 }
 
 const renderScrimbaContributors = function () {
+  const loadAmount = maxLoadOfContributors > contributors.length
+    ? contributors.length
+    : maxLoadOfContributors
+  
   for (let i = 0; i < loadAmount; i++) {
-    if (checkAllContributorsLoaded()) return
     let randomIndex = randomContributor();
     createScrimbaContributorsElements(randomIndex)
     // Delete selected element

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -111,7 +111,7 @@ const createUserCommentEl = function (index) {
 }
 
 const checkAllContributorsLoaded = function () {
-  return loadCount >= contributors.length
+  return contributors.length === 0;
 }
 
 /*

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -5,6 +5,9 @@ import { contributors } from "./contributors.js";
 const scrimbaContributorsContainerEl = document.querySelector('.scrimba-contributors--container');
 const scrimbaContributorsLoadMoreBtnEl = document.querySelector('.load-more');
 
+// How many contributors to render
+const maxLoadOfContributors = 6;
+
 /*
     The function below generates a random number for
     a random default profile image
@@ -184,7 +187,7 @@ const renderScrimbaContributors = function (loadAmount) {
 */
 scrimbaContributorsLoadMoreBtnEl.addEventListener('click', function () {
   if (!checkAllContributorsLoaded()) {
-    renderScrimbaContributors();
+    renderScrimbaContributors(maxLoadOfContributors);
   }
   if (checkAllContributorsLoaded()) {
     scrimbaContributorsLoadMoreBtnEl.remove()
@@ -192,7 +195,7 @@ scrimbaContributorsLoadMoreBtnEl.addEventListener('click', function () {
 })
 
 const init = function () {
-  renderScrimbaContributors();
+  renderScrimbaContributors(maxLoadOfContributors);
 }
 
 init()

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -121,6 +121,9 @@ const createMoreContributorsElements = function () {
   loadCount = document.querySelectorAll('.scrimba-contributors-card').length;
 }
 
+const checkAllContributorsLoaded = function () {
+  return loadCount >= contributors.length
+}
 
 /*
     Below are a bunch of append element functions

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -168,7 +168,7 @@ const createScrimbaContributorsElements = function (index) {
   appendScrimbaContributorsContainerEl(scrimbaContributorsCardEl)
 }
 
-const randomRender = function (loadAmount) {  
+const renderScrimbaContributors = function (loadAmount) {  
   for (let i = 0; i < loadAmount; i++) {
     if (checkAllContributorsLoaded()) return
     let randomIndex = randomContributor();
@@ -176,22 +176,6 @@ const randomRender = function (loadAmount) {
     // Delete selected element
     contributors.splice(randomIndex, 1)
   }
-}
-
-const renderScrimbaContributors = function () {
-  randomRender(6)
-  // let randomPick = randomContributor();
-  // let buffer = 0;
-  
-  // for (let i = 0; buffer !== loadAmount; i++) {
-  //   if (contributors[randomPick].load_check) {
-  //     randomPick = randomContributor();
-  //   } else {
-  //     createScrimbaContributorsElements(randomPick);
-  //     contributors[randomPick].load_check = true
-  //     buffer++
-  //   }
-  // }
 }
 
 /* 

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -5,8 +5,6 @@ import { contributors } from "./contributors.js";
 const scrimbaContributorsContainerEl = document.querySelector('.scrimba-contributors--container');
 const scrimbaContributorsLoadMoreBtnEl = document.querySelector('.load-more');
 
-let loadAmount, loadCount, currentContributors;
-
 /*
     The function below generates a random number for
     a random default profile image
@@ -216,9 +214,6 @@ scrimbaContributorsLoadMoreBtnEl.addEventListener('click', function () {
 })
 
 const init = function () {
-  loadAmount = 6;
-  currentContributors = [];
-  loadCount = document.querySelectorAll('.scrimba-contributors-card').length;
   renderScrimbaContributors();
 }
 

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -184,10 +184,7 @@ const randomRender = function () {
 }
 
 const renderScrimbaContributors = function () {
-  if (contributors.length <= loadAmount) {
-    scrimbaContributorsLoadMoreBtnEl.classList.add('hide')
-  }
-  randomRender()
+  randomRender(6)
   // let randomPick = randomContributor();
   // let buffer = 0;
   

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -171,7 +171,7 @@ const createScrimbaContributorsElements = function (index) {
   appendScrimbaContributorsContainerEl(scrimbaContributorsCardEl)
 }
 
-const renderScrimbaContributors = function (loadAmount) {  
+const renderScrimbaContributors = function () {
   for (let i = 0; i < loadAmount; i++) {
     if (checkAllContributorsLoaded()) return
     let randomIndex = randomContributor();
@@ -187,7 +187,7 @@ const renderScrimbaContributors = function (loadAmount) {
 */
 scrimbaContributorsLoadMoreBtnEl.addEventListener('click', function () {
   if (!checkAllContributorsLoaded()) {
-    renderScrimbaContributors(maxLoadOfContributors);
+    renderScrimbaContributors();
   }
   if (checkAllContributorsLoaded()) {
     scrimbaContributorsLoadMoreBtnEl.remove()
@@ -195,7 +195,7 @@ scrimbaContributorsLoadMoreBtnEl.addEventListener('click', function () {
 })
 
 const init = function () {
-  renderScrimbaContributors(maxLoadOfContributors);
+  renderScrimbaContributors();
 }
 
 init()

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -199,9 +199,12 @@ const renderScrimbaContributors = function () {
     contriutors per click
 */
 scrimbaContributorsLoadMoreBtnEl.addEventListener('click', function () {
-  createMoreContributorsElements();
-  console.log(loadCount);
-  scrimbaContributorsLoadMoreBtnEl.remove();
+  if (!checkAllContributorsLoaded()) {
+    renderScrimbaContributors();
+  }
+  if (checkAllContributorsLoaded()) {
+    scrimbaContributorsLoadMoreBtnEl.remove()
+  }
 })
 
 const init = function () {

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -110,17 +110,6 @@ const createUserCommentEl = function (index) {
   return userCommentEl;
 }
 
-const createMoreContributorsElements = function () {
-  loadCount = document.querySelectorAll('.scrimba-contributors-card').length;
-  randomRender()
-  // for (let i = loadCount; i < loadAmount + loadCount; i++) {
-  //   if (i < contributors.length) {
-  //     createScrimbaContributorsElements(i);
-  //   }
-  // }
-  loadCount = document.querySelectorAll('.scrimba-contributors-card').length;
-}
-
 const checkAllContributorsLoaded = function () {
   return loadCount >= contributors.length
 }

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -200,7 +200,6 @@ const renderScrimbaContributors = function () {
   //     buffer++
   //   }
   // }
-  loadCount = document.querySelectorAll('.scrimba-contributors-card').length;
 }
 
 /* 

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -168,18 +168,13 @@ const createScrimbaContributorsElements = function (index) {
   appendScrimbaContributorsContainerEl(scrimbaContributorsCardEl)
 }
 
-const randomRender = function () {
-  let randomPick = randomContributor();
-  let buffer = 0;
-
-  for (let i = 0; buffer !== loadAmount; i++) {
-    if (contributors[randomPick].load_check) {
-      randomPick = randomContributor();
-    } else {
-      createScrimbaContributorsElements(randomPick);
-      contributors[randomPick].load_check = true
-      buffer++
-    }
+const randomRender = function (loadAmount) {  
+  for (let i = 0; i < loadAmount; i++) {
+    if (checkAllContributorsLoaded()) return
+    let randomIndex = randomContributor();
+    createScrimbaContributorsElements(randomIndex)
+    // Delete selected element
+    contributors.splice(randomIndex, 1)
   }
 }
 

--- a/assets/javascript/contributors-component.js
+++ b/assets/javascript/contributors-component.js
@@ -121,11 +121,6 @@ const createMoreContributorsElements = function () {
   loadCount = document.querySelectorAll('.scrimba-contributors-card').length;
 }
 
-const checkLoadCount = function () {
-  if (loadCount >= contributors.length) {
-    scrimbaContributorsLoadMoreBtnEl.classList.add('hide')
-  }
-}
 
 /*
     Below are a bunch of append element functions
@@ -224,8 +219,6 @@ const renderScrimbaContributors = function () {
 */
 scrimbaContributorsLoadMoreBtnEl.addEventListener('click', function () {
   createMoreContributorsElements();
-  checkLoadCount();
-
   console.log(loadCount);
   scrimbaContributorsLoadMoreBtnEl.remove();
 })


### PR DESCRIPTION
The original problem in the issue was caused by an infinite for loop in `randomRender()`

```js
const randomRender = function () {
  let randomPick = randomContributor();
  let buffer = 0;

  for (let i = 0; buffer !== loadAmount; i++) {
    if (contributors[randomPick].load_check) {
      randomPick = randomContributor();
    } else {
      createScrimbaContributorsElements(randomPick);
      contributors[randomPick].load_check = true
      buffer++
    }
  }
}
```
The issue here is that `buffer++` no longer executes once all contributors have been marked with `load_check`, so it continues to execute `randomPick = randomContributor()`

To fix this, I mutated the contributors array with `splice` once a DOM element was created from it and opted not to use `load_check`. In the process, I removed some global variables that the original function depended on as they were no longer needed
